### PR TITLE
Fix PROCESSING_THREADS environment line in NPM GoAccess compose

### DIFF
--- a/nginx-proxy-manager-goaccess/npm-goaccess.yaml
+++ b/nginx-proxy-manager-goaccess/npm-goaccess.yaml
@@ -31,7 +31,7 @@ services:
       - CUSTOM_BROWSERS=Kuma:Uptime,TestBrowser:Crawler #optional - comma delimited, more information below
       - HTML_REFRESH=5 #optional - Refresh the HTML report every X seconds. https://goaccess.io/man
       - KEEP_LAST=90 #optional - Keep the last specified number of days in storage. https://goaccess.io/man
-      - PROCESSING_THREADS=1 #optional - This parameter sets the number of concurrent processing threads in the program's execution, affecting log data analysis, typically adjusted based on CPU cores. Default is 1. https://goaccess.io/man
+        - PROCESSING_THREADS=1 # optional - number of concurrent processing threads; default 1
     volumes:
       - /home/notolac/nginx-proxy-manager/data/logs:/opt/log:ro #required - path to your Nginx Proxy Manager logs
       #- /path/to/host/custom:/opt/custom #optional, required if using log_type = CUSTOM #change to the location of your choice


### PR DESCRIPTION
## Summary
- fix PROCESSING_THREADS env var comment to be a single line

## Testing
- `docker compose -f nginx-proxy-manager-goaccess/npm-goaccess.yaml config` *(command not found)*
- `yamllint nginx-proxy-manager-goaccess/npm-goaccess.yaml` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973332abf88321b36de87addddd284